### PR TITLE
Error when using StatefulView on a window element. 

### DIFF
--- a/backbone.statemachine.js
+++ b/backbone.statemachine.js
@@ -205,7 +205,7 @@ Backbone.StatefulView = (function(Backbone, _){
     _.extend(StatefulView.prototype, Backbone.View.prototype, Backbone.StateMachine, {
 
         toState: function(name) {
-            if (this.el) {
+            if (this.el && this.el.hasOwnProperty("className")) {
                 $(this.el).removeClass((this.stateClassName || ''));
                 this.stateClassName = (this._states[name].className || name);
                 $(this.el).addClass(this.stateClassName);


### PR DESCRIPTION
Let's make sure that the element we're attempting to change the class name of actually has the className attribute.  The window element, for example, does not. 
