### PR TITLE
[fix] Allow anonymous functions in states declaration hash

### DIFF
--- a/backbone.statemachine.js
+++ b/backbone.statemachine.js
@@ -164,9 +164,15 @@ Backbone.StateMachine = (function(Backbone, _) {
             var methods = [], i, length, method;
 
             for (i = 0, length = methodNames.length; i < length; i++){
-                method = this[methodNames[i]];
-                if (!method) {
-                    throw new Error('Method "' + methodNames[i] + '" does not exist');
+                // first, check if this is an anonymous function
+                if(_.isFunction(methodNames[i])) {
+                    method = methodNames[i];
+                } else {
+                    // else, get the function from the View
+                    method = this[methodNames[i]];
+                    if (!method) {
+                        throw new Error('Method "' + methodNames[i] + '" does not exist');
+                    }
                 }
                 methods.push(method);
             }


### PR DESCRIPTION
Sometimes, when the callbacks are short, it's easier to use
anonymous functions :

```
states: {
    visible: {
        enter: [function() { this.el.show(); }],
        leave: [function() { this.el.hide(); }]
    }
}
```

This is a proposed fix for issue #25
